### PR TITLE
Suggestions about @Transactional annotation usage

### DIFF
--- a/spring-boot-tutorial-registration-form/src/main/java/com/caveofprogramming/service/StatusUpdateService.java
+++ b/spring-boot-tutorial-registration-form/src/main/java/com/caveofprogramming/service/StatusUpdateService.java
@@ -5,11 +5,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.caveofprogramming.model.StatusUpdate;
 import com.caveofprogramming.model.StatusUpdateDao;
 
 @Service
+@Transactional
 public class StatusUpdateService {
 	
 	private final static int PAGESIZE = 10;


### PR DESCRIPTION
Hi, I found that there might be some minor improvements in your code. 

By adding @Transactional at the class level, many important aspects such as transaction propagation can be handled automatically. It can wrap your service in a generated proxy that joins an active transaction or starts a new one and commits or rolls the transaction back after your methods got executed.

Based on the advantages mentioned above, I recommend that you add the @Transactional annotation at the class level.

Hope my suggestions are useful!